### PR TITLE
GotoDocs feature

### DIFF
--- a/ContextSensitiveHelp.ahk
+++ b/ContextSensitiveHelp.ahk
@@ -1,0 +1,33 @@
+; Inspired from Context Sensitive Help in Any Editor -- by Rajat
+; https://www.autohotkey.com/docs/scripts/ContextSensitiveHelp.htm
+C_Cmd = %1%
+If (!C_Cmd)
+	Exit
+
+IfWinNotExist, AutoHotkey Help
+{
+	; Determine AutoHotkey's location:
+	RegRead, ahk_dir, HKEY_LOCAL_MACHINE, SOFTWARE\AutoHotkey, InstallDir
+	if ErrorLevel  ; Not found, so look for it in some other common locations.
+	{
+		if A_AhkPath
+			SplitPath, A_AhkPath,, ahk_dir
+		else IfExist ..\..\AutoHotkey.chm
+			ahk_dir = ..\..
+		else IfExist %A_ProgramFiles%\AutoHotkey\AutoHotkey.chm
+			ahk_dir = %A_ProgramFiles%\AutoHotkey
+		else
+		{
+			MsgBox Could not find the AutoHotkey folder.
+			return
+		}
+	}
+	Run %ahk_dir%\AutoHotkey.chm
+	WinWait AutoHotkey Help
+}
+; The above has set the "last found" window which we use below:
+WinActivate
+WinWaitActive
+StringReplace, C_Cmd, C_Cmd, #, {#}
+SendInput, !n{home}+{end}%C_Cmd%{enter}
+return

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,8 @@
+[
+  // Go to AHK documentation
+  { "keys": ["f1"], "command":"ahkgotodocs", "context":
+    [
+      { "key": "selector", "operator": "equal", "operand": "source.ahk" }
+    ]
+  },
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,8 @@
+[
+  // Go to AHK documentation
+  { "keys": ["f1"], "command":"ahkgotodocs", "context":
+    [
+      { "key": "selector", "operator": "equal", "operand": "source.ahk" }
+    ]
+  },
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -3,5 +3,11 @@
 		[
 			{ "key": "selector", "operator": "equal", "operand": "source.ahk" }
 		]
-	}
+	},
+        // Go to AHK documentation
+        { "keys": ["f1"], "command":"ahkgotodocs", "context":
+                [
+                        { "key": "selector", "operator": "equal", "operand": "source.ahk" }
+                ]
+        }
 ]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you have the default Sublime keybindings intact, then:
 * <kbd>Ctrl+B</kbd> will run the current file (with AutoHotkey.exe)
 * <kbd>Ctrl+Shift+B</kbd> will compile the current file (with Ahk2Exe.exe)
 * <kbd>Ctrl+Alt+H</kbd> will open a popup help for the keyword under the cursor.
+* <kbd>F1</kbd> will show the help file page for the selected AutoHotkey command or keyword. If nothing is selected, the command name will be extracted from the beginning of the current line.
 
 ## Advanced Configuration
 For the build system and ahkrun, ahkrunpiped, and ahkcompile commands, if you have a non-default installation then you will need to set your specific path to AutoHotkey.exe and Ahk2Exe.exe in a file named AutoHotkey.sublime-settings in your User folder. You can access these settings file from the Menu `Preferences > Package Settings > AutoHotkey`. You should make a copy of `AutoHotkey Settings - Default` at `AutoHotkey Settings - User` and modify there since then any settings defined in your User folder will take precedence and the package can still update itself without overwriting your custom settings.
@@ -23,8 +24,9 @@ The ahkrunpiped command will allow you to run your code as a piped text string t
 The ahkpopuphelp command shows a popup when it is called while the cursor (i.e. caret) is on a command, function or directive. Its default key binding is <kbd>Ctrl+Alt+H</kbd>. This feature works only in Sublime Text builds prior to 3070. For past versions, this shows a console message stating this fact.
 
 ## Goto-documentation Integration
-Instructions on how to configure goto-documentation plugin for AutoHotkey (F1 Hotkey will take you to documentation for word under cursor)
-* http://www.autohotkey.com/board/topic/46447-sublime-text-editor-very-nice/page-3#entry540187
+SublimeAutoHotkey provides an ``ahkgotodocs`` command. This is mapped to <kbd>F1</kbd> by default.
+
+Alternatively, follow these [instructions](http://www.autohotkey.com/board/topic/46447-sublime-text-editor-very-nice/page-3#entry540187) on how to configure goto-documentation plugin for AutoHotkey using [sublime-text-2-goto-documentation](#https://github.com/kemayo/sublime-text-2-goto-documentation).
 
 ## Credits
 * S0und: http://www.autohotkey.com/board/topic/46447-sublime-text-editor-very-nice/page-2#entry529723
@@ -33,3 +35,4 @@ Instructions on how to configure goto-documentation plugin for AutoHotkey (F1 Ho
 * ahkrunpiped, Coco: https://gist.github.com/cocobelgica/6296475
 * ahkrunpiped, greycode: https://gist.github.com/grey-code/4728413
 * ahkrunpiped, Lexikos: http://www.autohotkey.com/board/topic/23575-how-to-run-dynamic-script-through-a-pipe/
+* gotodocs, Rajat: https://www.autohotkey.com/docs/scripts/ContextSensitiveHelp.htm

--- a/gotodocs.py
+++ b/gotodocs.py
@@ -1,0 +1,27 @@
+import sublime, sublime_plugin
+import subprocess
+import os
+
+from .utils import find_in_settings
+
+
+CONTEXT_HELP = os.path.join(
+        os.path.dirname(__file__),
+        'ContextSensitiveHelp.ahk'
+)
+
+
+class ahkgotodocs(sublime_plugin.TextCommand):
+    def run(self, edit):
+        AutoHotKeyExePath = find_in_settings("AutoHotKeyExePath")
+        region = self.view.sel()[0]
+        if region.empty():
+            line = self.view.line(region)
+            line_contents = self.view.substr(line)
+            keyword = line_contents.split(None, 1)[0]
+        else:
+            keyword = self.view.substr(region)
+        # print("Keyword: %s" % keyword)
+        cmd = [AutoHotKeyExePath, CONTEXT_HELP, keyword]
+        # print("Command: %s" % cmd)
+        subprocess.call(cmd)


### PR DESCRIPTION
## Summary

Integrate [Context Sensitive Help](#https://www.autohotkey.com/docs/scripts/ContextSensitiveHelp.htm) AHK script into plugin. 

## Motivation

I was using the aforementioned AHK script for a while and liked that it brought up the AutoHotkey help file -- as opposed to a webpage. However, I was annoyed by the fact that it would set a context-insensitive hotkey for my Sublime Text. While a could've parsed the title for a ".ahk" to obtain context, this felt very hacky to me.

## Notes

This shares a commit with PR #22.