### PR TITLE
Update AHK-TrayIcon.sublime-snippet

### DIFF
--- a/AHK-TrayIcon.sublime-snippet
+++ b/AHK-TrayIcon.sublime-snippet
@@ -1,9 +1,9 @@
 <snippet>
-	<content>SplitPath, A_ScriptName, , , , thisscriptname
+	<content><![CDATA[SplitPath, A_ScriptName, , , , thisscriptname
 If( !A_IsCompiled && FileExist(A_ScriptDir . "\" . thisscriptname . ".ico")) {
 	Menu, Tray, Icon, %A_ScriptDir%\%thisscriptname%.ico
 }
 
-</content>
+]]></content>
 	<scope>source.ahk</scope>
 </snippet>


### PR DESCRIPTION
Updated AHK-TrayIcon.sublime-snippet to correct wrong syntax of content.
