### PR TITLE
Fix hotkeyline.ahk

### DIFF
--- a/AutoHotkey.tmLanguage
+++ b/AutoHotkey.tmLanguage
@@ -120,7 +120,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(.+)(::)</string>
+			<string>^\s*(\S+(?:\s+&\s+\S+)*)(::)</string>
 			<key>name</key>
 			<string>hotkeyline.ahk</string>
 		</dict>


### PR DESCRIPTION
`if !(SubStr(oItem.path, 1, 3) = "::{")` were treated as a hotkey line:

![not hotkeyline](https://user-images.githubusercontent.com/4450756/59578489-fe0d0280-90fa-11e9-936e-fc1567e82612.png)

There are 2 rules for hotkey syntax as I know:
1. Non-space characters. For example `Lbutton::` or `^#Lbutton::`
2. With space and `&` character. For example `a & b::` or `a & b & c::`

Current hotkeyline were matching all charcters with `.+`, I have changed the regex to the limited 2 rules mentioned above.

**Before**: `<string>^\s*(.+)(::)</string>`
**After**: `<string>^\s*(\S+(?:\s+&\s+\S+)*)(::)</string>`