### PR TITLE
Use encoded ampersand in hotkeyline.ahk

### DIFF
--- a/AutoHotkey.tmLanguage
+++ b/AutoHotkey.tmLanguage
@@ -120,7 +120,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(\S+(?:\s+&\s+\S+)*)(::)</string>
+			<string>^\s*(\S+(?:\s+&amp;\s+\S+)*)(::)</string>
 			<key>name</key>
 			<string>hotkeyline.ahk</string>
 		</dict>


### PR DESCRIPTION
👋  I'm the lead maintainer of https://github.com/github/linguist which uses this grammar for syntax highlighting of AutoHotKey files on GitHub.com.

I'm in the process of making a new release and our grammar compiler has detected an error in your grammar that was introduced in https://github.com/ahkscript/SublimeAutoHotkey/pull/53:

```
Grammar conversion failed. File `AutoHotkey.tmLanguage` failed to parse: XML syntax error on line 123: invalid character entity & (no semicolon)
```

The issue is the single `&` introduced in that PR is not a valid in XML and needs to be encoded.  This PR does just that.