### PR TITLE
block comments broken if indented

### DIFF
--- a/AutoHotkey.tmLanguage
+++ b/AutoHotkey.tmLanguage
@@ -33,9 +33,9 @@
 
 		<dict>
 			<key>begin</key>
-			<string>^[\t ]*/\*</string>
+			<string>^\s*/\*</string>
 			<key>end</key>
-			<string>^[\t ]*\*/</string>
+			<string>^\s*\*/</string>
 			<key>name</key>
 			<string>comment.block.ahk</string>
 		</dict>

--- a/AutoHotkey.tmLanguage
+++ b/AutoHotkey.tmLanguage
@@ -33,9 +33,9 @@
 
 		<dict>
 			<key>begin</key>
-			<string>^/\*</string>
+			<string>^[\t ]*/\*</string>
 			<key>end</key>
-			<string>^\*/</string>
+			<string>^[\t ]*\*/</string>
 			<key>name</key>
 			<string>comment.block.ahk</string>
 		</dict>


### PR DESCRIPTION
The documentation specifies:
> the `/*` and `*/` symbols can be used to comment out an entire section, but only if the symbols appear at the beginning of a line

Source: https://www.autohotkey.com/docs/Language.htm#comments

The implementation found in `AutoHotkey.tmLanguage` is correct:
https://github.com/ahkscript/SublimeAutoHotkey/blob/951f41ab2e6c1624903538bbd4648b689389f188/AutoHotkey.tmLanguage#L36-L38

However, this is broken if comments are indented such as:
```ahk
#Warn
MsgBox 1

	/*
	 * indented comment line 1
	   MsgBox Comment
	 * indented comment line 3
	 */

MsgBox 2
```
Running the above test script executes with no warnings or errors, and shows only two message boxes (1,2).

I have posted a new issue under `Lexikos/AutoHotkey_L-Docs`:
https://github.com/Lexikos/AutoHotkey_L-Docs/issues/398

The implementation should instead be:
```xml
 <string>^[\t ]*/\*</string>
 <key>end</key>
 <string>^[\t ]*\*/</string>
```
Comments?